### PR TITLE
Banlist/Format Validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         run: cd server && npm run lint
 
       - name: Run Tests for client
-        run: cd client && npm run test
+        run: cd client npm test
 
       - name: Run Tests for server
-        run: cd server && npm run test
+        run: cd server npm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         run: cd server && npm run lint
 
       - name: Run Tests for client
-        run: cd client npm test
+        run: cd client && npm test
 
       - name: Run Tests for server
-        run: cd server npm test
+        run: cd server && npm test

--- a/client/src/components/FileUploader/FileUploader.tsx
+++ b/client/src/components/FileUploader/FileUploader.tsx
@@ -26,9 +26,11 @@ export default function FileUploader() {
   useEffect(() => {
     const getData = async  () => {
       const results = await getFilters();
-      setFilters(await results.json());
-    };
-    if(filter.length<=0){
+      const filterStrings = await results.json();
+      if(filterStrings.length > 0 ) {
+        setFilters(filterStrings);
+      };};
+    if(filters.length<=0 && filter.length>0){
       getData();
     }
 

--- a/client/src/components/FileUploader/FileUploader.tsx
+++ b/client/src/components/FileUploader/FileUploader.tsx
@@ -26,10 +26,9 @@ export default function FileUploader() {
   useEffect(() => {
     const getData = async  () => {
       const results = await getFilters();
-      console.log(results.json());
       setFilters(await results.json());
     };
-    if(filter.length>0){
+    if(filter.length<=0){
       getData();
     }
 
@@ -82,7 +81,7 @@ export default function FileUploader() {
     } else {
       toast.error("Incorrect file type");
     }
-  }, []);
+  }, [filters]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 
@@ -105,7 +104,6 @@ export default function FileUploader() {
       setKonamiId(value);
     }
   };
-
   return (
     <div className="layout-container">
       <div className="inputs-upload-container">
@@ -161,7 +159,8 @@ export default function FileUploader() {
             <select value={filter} onChange={handleFilter}>
               <option value="">Select Format</option>
               {
-                filters.map((filter, index) => <option key={index} value={`${filter}`}>{filter}</option>)
+                filters.map((filter, index) => {
+                  return <option key={index} value={`${filter}`}>{filter}</option>;})
               }
             </select></label>
           

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -254,7 +254,7 @@ export const getFormats = async () => {
     const formats = await page.evaluate(() => {
       const rootElement = document.querySelector(".format-menu");
       const children = rootElement.children;
-      const contentArray = [];
+      const contentArray = ["Current"];
       for (let i = 0; i < children.length; i++) {
         contentArray.push(children[i].querySelector(".format-button div").innerHTML);
       }

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -158,12 +158,13 @@ export const fillForm = async (deckList, playerInfo) => {
     form.getTextField("First  Middle Names").setText(firstName);
     form.getTextField("Last Names").setText(lastName);
     form.getTextField("CARD GAME ID").setText(konamiId);
-
     const countOccurrences = (array, element) => array.filter(item => item.name.S === element.name.S).length;
     const fillDeck = async (deckType, deckCards, filledOutCards, cardNumber) => {
-      const bannedCards =  await banListValidator(filter, deckCards);
-      if (bannedCards) {
-        return bannedCards;
+      if (filter) {
+        const bannedCards =  await banListValidator(filter, deckCards);
+        if (bannedCards) {
+          return bannedCards;
+        }
       }
       deckCards.forEach((card) => {
         if ((deckType === "Monster" || deckType === "Spell" || deckType === "Trap") && cardNumber > MAX_MAIN_DECK_TYPE_CARDS) {

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -106,30 +106,36 @@ export const getDeck = async (ydk) => {
   let fullDeck = { main: [], extra: [], side: [] };
 
   for (const id of singlesDeckIds.main) {
-    const item = await getItem(DYNAMODB_TABLE_NAME, id);
+    const params = {
+      TableName: DYNAMODB_TABLE_NAMES.YGO_CARD_DATABASE,
+      Key: { card_id: { S: id.toString() } }
+    };
+    const item = await getItem(params);
     if (item) fullDeck.main.push(item);
   }
 
   for (const id of singlesDeckIds.extra) {
-    const item = await getItem(DYNAMODB_TABLE_NAME, id);
+    const params = {
+      TableName: DYNAMODB_TABLE_NAMES.YGO_CARD_DATABASE,
+      Key: { card_id: { S: id.toString() } }
+    };
+    const item = await getItem(params);
     if (item) fullDeck.extra.push(item);
   }
 
   for (const id of singlesDeckIds.side) {
-    const item = await getItem(DYNAMODB_TABLE_NAME, id);
+    const params = {
+      TableName: DYNAMODB_TABLE_NAMES.YGO_CARD_DATABASE,
+      Key: { card_id: { S: id.toString() } }
+    };
+    const item = await getItem(params);
     if (item) fullDeck.side.push(item);
   }
 
   return fullDeck;
 };
 
-const getItem = async (tableName, cardId) => {
-  //write tests for this
-  const params = {
-    TableName: tableName,
-    Key: { card_id: { S: cardId.toString() } }
-  };
-
+const getItem = async (params) => {
   try {
     const { Item } = await client.send(new GetItemCommand(params));
 

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -202,7 +202,7 @@ export const fillForm = async (deckList, playerInfo) => {
        return acc;
      }, [])
     ;
-    // Filter out any null values that were added to maintain the array structure
+    //Combines together the array of banned cards and returns a complete string of all banned cards
 
     if (bannedCardsArr.length > 0) {
       const bannedCardsString  = () =>{
@@ -254,6 +254,7 @@ export const getFormats = async () => {
     const formats = await page.evaluate(() => {
       const rootElement = document.querySelector(".format-menu");
       const children = rootElement.children;
+      //I add Current string here becuase its the most current format. I thought to manually add this because I will probably get all formats at some point but this is much easier than scraping the page for it
       const contentArray = ["Current"];
       for (let i = 0; i < children.length; i++) {
         contentArray.push(children[i].querySelector(".format-button div").innerHTML);
@@ -374,6 +375,8 @@ export const getFormatFilters = async () => {
     console.error("Error scanning table:", err);
     throw err;
   } };
+
+//This returns an object of all the banned cards
 const banListValidator = async (format, cardList) => {
   const params = {
     TableName: DYNAMODB_TABLE_NAMES.FORMATS,

--- a/server/server.js
+++ b/server/server.js
@@ -16,7 +16,6 @@ app.listen(port, () => {
 
 const upload = multer({ storage: multer.memoryStorage() });
 const handlePostYDKRoute = async (req, res) => {
-  //turn this into a helper function isValidRequest
   const file = req.file;
   isValidFile(file);
   try {

--- a/server/server.js
+++ b/server/server.js
@@ -26,7 +26,8 @@ const handlePostYDKRoute = async (req, res) => {
     const playerInfo = {
       firstName: req.body.firstName,
       lastName: req.body.lastName,
-      konamiId: req.body.konamiId
+      konamiId: req.body.konamiId,
+      filter: req.body.filter
     };
     const loadedDeck = await getDeck(file.buffer);
     const filledForm = await fillForm(loadedDeck, playerInfo);
@@ -47,7 +48,6 @@ const handleDefaultGetRoute = (req, res) => {
 
 const handleGetFiltersRoute = async (req, res) => {
   const filters = await getFormatFilters();
-  console.log(filters);
   res.send(JSON.stringify(filters));
 };
 

--- a/server/tests/helpers.test.js
+++ b/server/tests/helpers.test.js
@@ -20,7 +20,7 @@ describe('helpers', () => {
     });
 
     test('writeFromYGOPRO should fetch cards from API and store them in DynamoDB', async () => {
-        axios.get.mockResolvedValue({ data: { data: [{ id: '123', name: 'Test Card', type: 'Monster' }] } });
+        axios.get.mockResolvedValue({ data: { data: [{ id: '123', originalname: 'Test Card', type: 'Monster' }] } });
         const mockClient = new DynamoDBClient();
         const putItemSpy = jest.spyOn(mockClient, 'send').mockResolvedValue({});
 
@@ -65,17 +65,17 @@ describe('helpers', () => {
         expect(() =>isValidFile()).toThrow("No file found")
     })
     test('isValidFile should throw an error when the file type is not ydk', () => {
-        const invalidFile = { name: 'test.txt', size: MAX_FILE_SIZE - 1 }; 
+        const invalidFile = { originalname: 'test.txt', size: MAX_FILE_SIZE - 1 }; 
         expect(() => isValidFile(invalidFile)).toThrow("Invalid file type");
       });
 
     it(' isValidFile should throw an error when the file size exceeds the maximum allowed size', () => {
-        const largeFile = { name: 'test.ydk', size: MAX_FILE_SIZE + 1 }; 
+        const largeFile = { originalname: 'test.ydk', size: MAX_FILE_SIZE + 1 }; 
         expect(() => isValidFile(largeFile)).toThrow("Max file size exceeded");
       });
     
       it('isValidFile should return true for a valid file', () => {
-        const validFile = { name: 'test.ydk', size: MAX_FILE_SIZE - 1 };
+        const validFile = { originalname: 'test.ydk', size: MAX_FILE_SIZE - 1 };
         expect(() => isValidFile(validFile)).not.toThrow();
       });
 });


### PR DESCRIPTION

### Description

This PR Does some refactoring on existing code and adds the ability to validate the deck you send based on a specified banlist It includes the following changes:

    - Refactors the put request function to take in request params instead of user info 
    - Fixes bug with filter names being populated on client side
    - I caught a bug that I introduced about a month ago that made it so that if there were multiple cards in a deck it only showed as just one
    - Adds banlistValidator function which returns all banned cards in the deck
    - Refactors how the deck is filled to work with the banlistValidator

### Screenshots


### Type of Change

- [x]  New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation update

### Expected Behavior
The user should be able to upload a ydk file like normal with or without a filter string. If a filter string is selected when you send the form you should not get a filled form back or any form for that matter.You should receive an error toast saying that you have banned cards and it should let the user know which card are banned in the deck.


### How Has This Been Tested?

- **Manual Testing:**
    
    - Filled decklist now populates with the correct card amount 
    - I select a populated filter/format string and sent to to server with my file and it correctly returns an error with the banned cards in the deck
- **Automated Tests:**
    

### Checklist

- [x]  I have performed a self-review of my code.
- [x]  I have commented my code, particularly in hard-to-understand areas.
- [ ]  I have made corresponding changes to the documentation.
- [ ]  I have added tests that prove my fix is effective or that my feature works.
- [x]  New and existing unit tests pass locally with my changes.